### PR TITLE
Issue/24

### DIFF
--- a/includes/options.php
+++ b/includes/options.php
@@ -30,8 +30,8 @@ function yelp_widget_activate() {
 function yelp_widget_add_options_page() {
 	// Add the menu option under Settings, shows up as "Yelp API Settings" (second param)
 	$page = add_submenu_page( 'options-general.php', //The parent page of this menu
-		__( 'Yelp Widget Pro Settings', 'ywp' ), //The Menu Title
-		__( 'Yelp Widget Pro', 'ywp' ), //The Page Title
+		__( 'Yelp Widget Pro Settings', 'ywp' ), //The Page Title
+		__( 'Yelp Reviews', 'ywp' ), //The Menu Title
 		'manage_options', // The capability required for access to this item
 		'yelp_widget', // the slug to use for the page in the URL
 		'yelp_widget_options_form' ); // The function to call to render the page

--- a/includes/options.php
+++ b/includes/options.php
@@ -181,19 +181,20 @@ function yelp_widget_options_form() {
 							<h3 class="hndle"><span><?php _e( 'Yelp Widget Pro Introduction', 'ywp' ); ?></span></h3>
 
 							<div class="inside">
-								<p><?php _e( 'Thanks for choosing Yelp Widget Pro! <strong>To start using Yelp Widget Pro you must have a valid Yelp API key</strong>.  Don\'t worry, it\'s <em>free</em> and very easy to get one! For instructions, please check out the <a href="http://wordimpress.com/docs/yelp-widget-pro/#how-to-request-a-yelp-api-key" target="_blank" class="new-window">How to Request a Yelp API Key</a> screencast.', 'ywp' ); ?></p>
+								<p>
+								<?php
+								$widgets_url = admin_url( 'widgets.php' );
+								$link = sprintf( wp_kses( __( 'Thanks for choosing Yelp Widget Pro! To get started, head on over to your <a href="%s">Widgets page</a> and add Yelp Widget Pro to one of your active widget areas.', 'ywp' ), array(  'a' => array( 'href' => array() ) ) ), esc_url( $widgets_url ) );
+								echo $link;
+								?>
+								</p>
 
-								<p><strong><?php _e( 'Yelp API Activation Instructions:', 'ywp' ); ?></strong></p>
+								<p><strong><?php _e( 'Need Support?', 'ywp' ); ?></strong></p>
 
-								<ol>
-									<li><?php _e( 'Sign into Yelp or create an account if you don\'t have one already', 'ywp' ); ?></li>
-									<li><?php _e( 'Once logged in, <a href="http://www.yelp.com/developers/getting_started/api_access" target="_blank" class="new-window">sign up for API access', 'ywp' ); ?></a></li>
-									<li><?php _e( 'After you have been granted an API key copy-and-paste the API v2.0 information into the appropriate fields below', 'ywp' ); ?></li>
-									<li><?php _e( 'Click update to activate and begin using Yelp Widget Pro', 'ywp' ); ?></li>
-								</ol>
+								<p><?php _e( 'If you have any problems with this plugin or ideas for improvements, please use the <a href="https://wordpress.org/support/plugin/yelp-widget-pro">WordPress.org Support Forums</a> where you can search the existing topics or create one of your own.', 'ywp' ); ?></p>
 
 								<p>
-									<strong><?php _e( 'Like this plugin?  Give it a like on Facebook:', 'ywp' ); ?></strong>
+									<strong><?php _e( 'Like this plugin? Follow along with WordImpress:', 'ywp' ); ?></strong>
 								</p>
 
 								<div class="social-items-wrap">
@@ -276,21 +277,12 @@ function yelp_widget_options_form() {
 
 							<div class="inside">
 
-								<p><?php _e( 'Yelp Widget Premium is a significant upgrade to Yelp Widget Pro that adds many features that will allow you to further customize your widgets with Google Maps, Yelp review snippets, additional graphics and display options plus so much more! Also included is priority support, auto updates, and well documented shortcodes to display Yelp in any page or post', 'ywp' ); ?>.</p>
+								<p><?php _e( '<a href="http://wordimpress.com/plugins/yelp-widget-pro/">Yelp Widget Premium</a> is a significant upgrade to Yelp Widget Pro that adds features such as Yelp review lists, Google Maps, and more!', 'ywp' ); ?>.</p>
+
+								<p><?php _e( 'Also included is Priority Support, updates, and well-documented shortcodes to display Yelp in any page or post', 'ywp' ); ?>.</p>
 							</div>
 						</div>
 						<!-- /.premium-metabox -->
-
-						<div id="yelp-widget-pro-support" class="postbox">
-							<div class="handlediv" title="Click to toggle"><br></div>
-							<h3 class="hndle"><span><?php _e( 'Need Support?', 'ywp' ); ?></span></h3>
-
-							<div class="inside">
-								<p><?php _e( 'If you have any problems with this plugin or ideas for improvements or enhancements, please use the WordImpress support forum: <a href="http://wordimpress.com/support/forum/yelp-widget-pro/" target="_blank" class="new-window">Support Forums</a>. Please note, support is prioritized for <a href="http://wordimpress.com/plugins/yelp-widget-pro/" title="Upgrade to Yelp Widget Premium" target="_blank" class="new-window">Premium Users</a>.', 'ywp' ); ?></p>
-							</div>
-							<!-- /.inside -->
-						</div>
-						<!-- /.yelp-widget-pro-support -->
 
 					</div>
 					<!-- /.sidebar-sortables -->

--- a/includes/options.php
+++ b/includes/options.php
@@ -162,6 +162,14 @@ function yelp_widget_options_form() {
 		</div>
 		<form id="yelp-settings" method="post" action="options.php">
 
+			<?php
+			// Tells Wordpress that the options we registered are being
+			// handled by this form
+			settings_fields( 'yelp_widget_settings' );
+
+			// Retrieve stored options, if any
+			$options = get_option( 'yelp_widget_settings' ); ?>
+
 			<div class="metabox-holder">
 
 				<div class="postbox-container" style="width:75%">
@@ -227,59 +235,6 @@ function yelp_widget_options_form() {
 							<!-- /.inside -->
 						</div>
 						<!-- /#yelp-widget-intro -->
-
-						<div class="postbox" id="api-options">
-
-							<h3 class="hndle"><span><?php _e( 'Yelp API v2.0 Information', 'ywp' ); ?></span></h3>
-
-							<div class="inside">
-								<?php
-								// Tells Wordpress that the options we registered are being
-								// handled by this form
-								settings_fields( 'yelp_widget_settings' );
-
-								// Retrieve stored options, if any
-								$options = get_option( 'yelp_widget_settings' ); ?>
-
-								<div class="control-group">
-									<div class="control-label">
-										<label for="yelp_widget_consumer_key"><?php _e( 'Consumer Key', 'ywp' ); ?>: </label>
-									</div>
-									<div class="controls">
-										<input type="text" id="yelp_widget_consumer_key" name="yelp_widget_settings[yelp_widget_consumer_key]" value="<?php echo yelp_widget_option( 'yelp_widget_consumer_key', $options ); ?>" />
-									</div>
-								</div>
-
-								<div class="control-group">
-									<div class="control-label">
-										<label for="yelp_widget_consumer_secret"><?php _e( 'Consumer Secret', 'ywp' ); ?>: </label>
-									</div>
-									<div class="controls">
-										<input type="text" id="yelp_widget_consumer_secret" name="yelp_widget_settings[yelp_widget_consumer_secret]" value="<?php echo yelp_widget_option( 'yelp_widget_consumer_secret', $options ); ?>" />
-									</div>
-								</div>
-
-								<div class="control-group">
-									<div class="control-label">
-										<label for="yelp_widget_token"><?php _e( 'Token', 'ywp' ); ?>: </label>
-									</div>
-									<div class="controls">
-										<input type="text" id="yelp_widget_token" name="yelp_widget_settings[yelp_widget_token]" value="<?php echo yelp_widget_option( 'yelp_widget_token', $options ); ?>" />
-									</div>
-								</div>
-
-								<div class="control-group">
-									<div class="control-label">
-										<label for="yelp_widget_token_secret"><?php _e( 'Token Secret', 'ywp' ); ?>: </label>
-									</div>
-									<div class="controls">
-										<input type="text" id="yelp_widget_token_secret" name="yelp_widget_settings[yelp_widget_token_secret]" value="<?php echo yelp_widget_option( 'yelp_widget_token_secret', $options ); ?>" />
-									</div>
-								</div>
-							</div>
-							<!-- /.inside -->
-						</div>
-						<!-- /#api-settings -->
 
 						<div class="postbox" id="yelp-widget-options">
 

--- a/widget.php
+++ b/widget.php
@@ -36,14 +36,14 @@ class Yelp_Widget extends WP_Widget {
 		$unsigned_url = "http://api.yelp.com/v2/";
 
 		// Token object built using the OAuth library
-		$yelp_widget_token        = $options['yelp_widget_token'];
-		$yelp_widget_token_secret = $options['yelp_widget_token_secret'];
+		$yelp_widget_token        = 'Z3J0Ecxir8c-Vx1_dHDlVnVFOvmWrQ5T';
+		$yelp_widget_token_secret = 'qx2cpAUz6UHnAlu53tcWOdH2LNg';
 
 		$token = new OAuthToken( $yelp_widget_token, $yelp_widget_token_secret );
 
 		// Consumer object built using the OAuth library
-		$yelp_widget_consumer_key    = $options['yelp_widget_consumer_key'];
-		$yelp_widget_consumer_secret = $options['yelp_widget_consumer_secret'];
+		$yelp_widget_consumer_key    = 'NLzpDyRu35JeHhOzQAIHuQ';
+		$yelp_widget_consumer_secret = '1eQpHwSO38jMSsI37QOjBWuroeQ';
 
 		$consumer = new OAuthConsumer( $yelp_widget_consumer_key, $yelp_widget_consumer_secret );
 
@@ -366,18 +366,7 @@ class Yelp_Widget extends WP_Widget {
 
 		$apiOptions = get_option( 'yelp_widget_settings' );
 
-		//Verify that the API values have been inputed prior to output
-		if ( empty( $apiOptions["yelp_widget_consumer_key"] ) || empty( $apiOptions["yelp_widget_consumer_secret"] ) || empty( $apiOptions["yelp_widget_token"] ) || empty( $apiOptions["yelp_widget_token_secret"] ) ) {
-			//the user has not properly configured plugin so diplay a warning
-			?>
-			<div class="alert alert-red"><?php _e( 'Please input your Yelp API information in the <a href="options-general.php?page=yelp_widget">plugin settings</a> page prior to enabling Yelp Widget Pro.', 'ywp' ); ?></div>
-		<?php
-		} //The user has properly inputted Yelp API info so output widget form so output the widget contents
-		else {
-
-			include( 'includes/widget-form.php' );
-
-		} //endif check for Yelp API key inputs
+		include( 'includes/widget-form.php' );
 
 	} //end form function
 

--- a/yelp-widget-pro.php
+++ b/yelp-widget-pro.php
@@ -53,7 +53,7 @@ function add_yelp_widget_css() {
 
 	$cssOption = get_option( 'yelp_widget_settings' );
 
-	if ( $cssOption && !array_key_exists('yelp_widget_disable_css', $cssOption) ) {
+	if ( ! $cssOption || ! array_key_exists('yelp_widget_disable_css', $cssOption) ) {
 
 		$url = plugins_url( YELP_PLUGIN_NAME . '/includes/style/yelp.css', dirname( __FILE__ ) );
 


### PR DESCRIPTION
Fixes https://github.com/WordImpress/Yelp-Widget-Premium/issues/24 for the free version.
Directs support to WordPress.org instead of closed WordImpress support forums.
Clarifies premium description and add inline link.
Changes menu title to `Yelp Reviews`.

## Before

![image](https://cloud.githubusercontent.com/assets/1938671/25418936/53746dc2-2a1d-11e7-9b9e-bb3a41d66caa.png)

## After

![image](https://cloud.githubusercontent.com/assets/1938671/25418874/f2ac48a2-2a1c-11e7-8ac8-db27cc6a5474.png)
